### PR TITLE
allow for custom user models

### DIFF
--- a/permission_backend_nonrel/admin.py
+++ b/permission_backend_nonrel/admin.py
@@ -3,8 +3,11 @@ from django.contrib import admin
 from django.utils.translation import ugettext
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.admin.sites import NotRegistered
-from django.contrib.auth.models import User, Group, Permission
+from django.contrib.auth.models import Group, Permission
 from django.contrib.admin.widgets import FilteredSelectMultiple
+
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 from .models import UserPermissionList, GroupPermissionList
 from .utils import update_permissions_user, \

--- a/permission_backend_nonrel/models.py
+++ b/permission_backend_nonrel/models.py
@@ -1,7 +1,10 @@
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import Group
 from django.db import models
 
 from djangotoolbox.fields import ListField
+
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 
 class UserPermissionList(models.Model):

--- a/permission_backend_nonrel/tests.py
+++ b/permission_backend_nonrel/tests.py
@@ -1,8 +1,11 @@
 from django.conf import settings
 from django.contrib.auth import authenticate
-from django.contrib.auth.models import User, Group, Permission, AnonymousUser
+from django.contrib.auth.models import Group, Permission, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 from .models import UserPermissionList, \
      GroupPermissionList


### PR DESCRIPTION
Third-party applications should not user the User model from django.contrib.auth.models directly, as users may customize this model. Apps should instead call django.contrib.auth.get_user_model() and use the returned class.
